### PR TITLE
use is_plain_arrayref instead of ref equality check

### DIFF
--- a/lib/MooseX/Extreme.pm
+++ b/lib/MooseX/Extreme.pm
@@ -122,7 +122,7 @@ sub field {
     $opts{is} //= 'ro';
 
     # "has [@attributes]" versus "has $attribute"
-    foreach my $attr ( 'ARRAY' eq ref $name ? @$name : $name ) {
+    foreach my $attr ( is_plain_arrayref($name) ? @$name : $name ) {
         my %options = %opts;    # copy each time to avoid overwriting
         $options{init_arg} = undef;
         $meta->add_attribute( $attr, %options );


### PR DESCRIPTION
... as was done/introduced in:

    commit dc7c3b0aa0730ccb13ef32a02f7eb1d2e5732395
    Author: Ovid <ovid@cpan.org>
    Date:   Thu May 19 08:32:05 2022 +0200
    Many more docs