### PR TITLE
Get 5.20 working (first version with postderef)

### DIFF
--- a/.github/workflows/dzil_tester.yml
+++ b/.github/workflows/dzil_tester.yml
@@ -17,6 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         perl-version:
+          - '5.20'
           - '5.22'
           - '5.24'
           - '5.26'

--- a/lib/MooseX/Extreme.pm
+++ b/lib/MooseX/Extreme.pm
@@ -2,7 +2,7 @@ package MooseX::Extreme;
 
 # ABSTRACT: Moose on Steroids
 
-use 5.22.0;
+use 5.20.0;
 use warnings;
 use feature qw(signatures);
 
@@ -114,7 +114,7 @@ This:
 Is sort of the equivalent to:
 
     package My::Class {
-        use v5.22.0;
+        use v5.20.0;
         use Moose;
         use MooseX::StrictConstructor;
         use feature qw( signatures postderef );
@@ -161,7 +161,7 @@ function every time you read or write that attribute, it will be cloned if
 it's a reference, ensuring that your object is effectively immutable.
 
     package My::Class {
-        use v5.22.0;
+        use v5.20.0;
         use MooseX::Extreme;
         use MooseX::Extreme::Types qw(NonEmptyStr HashRef);
 

--- a/lib/MooseX/Extreme/Core.pm
+++ b/lib/MooseX/Extreme/Core.pm
@@ -2,7 +2,7 @@ package MooseX::Extreme::Core;
 
 # ABSTRACT: Internal module for MooseX::Extreme
 
-use v5.22.0;
+use v5.20.0;
 use warnings;
 use parent 'Exporter';
 use feature qw(signatures postderef);

--- a/lib/MooseX/Extreme/Role.pm
+++ b/lib/MooseX/Extreme/Role.pm
@@ -26,8 +26,8 @@ sub init_meta {
 
     my $for_class = $params{for_class};
     Carp->import::into($for_class);
-    warnings->unimport('experimental::signatures');
-    feature->import(qw/signatures :5.22/);
+    warnings->unimport(qw(experimental::signatures experimental::postderef));
+    feature->import(qw/signatures postderef :5.20/);
     namespace::autoclean->import::into($for_class);
     true->import;              # no need for `1` at the end of the module
     MooseX::Role::WarnOnConflict->import::into($for_class);

--- a/lib/MooseX/Extreme/Tutorial.pod
+++ b/lib/MooseX/Extreme/Tutorial.pod
@@ -47,7 +47,7 @@ This:
 Is sort of the equivalent to:
 
     package My::Class {
-        use v5.22.0;
+        use v5.20.0;
         use Moose;
         use MooseX::StrictConstructor;
         use feature 'signatures';

--- a/t/basic.t
+++ b/t/basic.t
@@ -4,7 +4,6 @@ use lib 'lib';
 use Test::Most;
 
 package My::Names {
-    use v5.22.0;
     use MooseX::Extreme;
     use MooseX::Extreme::Types qw(compile Num NonEmptyStr Str PositiveInt ArrayRef);
     use List::Util 'sum';

--- a/t/clone.t
+++ b/t/clone.t
@@ -8,7 +8,6 @@ use Scalar::Util 'refaddr';
 my $CLONE_CALLED = 0;
 
 package My::Class {
-    use v5.22.0;
     use MooseX::Extreme;
     use MooseX::Extreme::Types qw(NonEmptyStr HashRef);
 

--- a/t/lib/Not/Corinna.pm
+++ b/t/lib/Not/Corinna.pm
@@ -1,5 +1,4 @@
 package Not::Corinna {
-    use v5.22.0;
     use MooseX::Extreme;
     use MooseX::Extreme::Types qw(compile Num NonEmptyStr Str PositiveInt ArrayRef);
     use List::Util 'sum';


### PR DESCRIPTION
See if we can get 5.20 working. It's the first version of Perl that supports postfix dereferencing. We can support more users this way.