### PR TITLE
Validate method names

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for MooseX-Extreme
 
 {{$NEXT}}
 
+          - Start adding exceptions
+          - Throw exceptions if attribute names or shortcut names are invalid
           - Support v5.20.0
           - Add github actions
           - Add postderef support

--- a/lib/Moose/Exception/InvalidAttributeDefinition.pm
+++ b/lib/Moose/Exception/InvalidAttributeDefinition.pm
@@ -1,0 +1,16 @@
+package Moose::Exception::InvalidAttributeDefinition;
+
+use Moose;
+extends 'Moose::Exception';
+our $VERSION = '0.1';
+with 'Moose::Exception::Role::Class';
+
+has 'attribute_name' => (
+    is            => 'ro',
+    isa           => 'Str',
+    required      => 1,
+    documentation => "The exception is thrown if an attribute name is invalid.",
+);
+
+__PACKAGE__->meta->make_immutable;
+1;

--- a/lib/MooseX/Extreme/Core.pm
+++ b/lib/MooseX/Extreme/Core.pm
@@ -27,9 +27,7 @@ sub param ( $meta, $name, %opt_for ) {
             $attr =~ s/^\+//;      # in case they're overriding a parent class attribute
             $options{init_arg} //= $attr;
         }
-        %options = _finalize_options( $meta, $attr, %options );
-        debug( "Setting param '$attr'", \%options );
-        $meta->add_attribute( $attr, %options );
+        _add_attribute( 'param', $meta, $attr, %options );
     }
 }
 
@@ -45,13 +43,11 @@ sub field ( $meta, $name, %opt_for ) {
         $options{init_arg} = undef;
         $options{lazy} //= 1;
 
-        %options = _finalize_options( $meta, $attr, %options );
-        debug( "Setting field '$attr'", \%options );
-        $meta->add_attribute( $attr, %options );
+        _add_attribute( 'field', $meta, $attr, %options );
     }
 }
 
-sub _finalize_options ( $meta, $name, %opt_for ) {
+sub _add_attribute ( $attr_type, $meta, $name, %opt_for ) {
     debug("Finalizing options for $name");
     state $shortcut_for = {
         predicate => sub ($value) {"has_$value"},
@@ -75,7 +71,8 @@ sub _finalize_options ( $meta, $name, %opt_for ) {
         %opt_for = _add_cloning_method( $meta, $name, %opt_for );
     }
 
-    return %opt_for;
+    debug( "Setting $attr_type, '$name'", \%opt_for );
+    $meta->add_attribute( $name, %opt_for );
 }
 
 sub _add_cloning_method ( $meta, $name, %opt_for ) {

--- a/t/exceptions.t
+++ b/t/exceptions.t
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+
+use lib 'lib';
+use Test::Most;
+use MooseX::Extreme::Core qw(param field);
+
+package Mock::Meta {
+    use MooseX::Extreme;
+    sub name {'My::Class'}
+}
+
+my $meta = Mock::Meta->new;
+throws_ok { param( $meta, 'foo', isa => 'Str', writer => 'foo_Array(x1233)' ) }
+'Moose::Exception::InvalidAttributeDefinition',
+  'We should get a proper exception if our attributes have invalid property names';
+
+throws_ok { param( $meta, '42foo', isa => 'Str', writer => 'set_foo' ) }
+'Moose::Exception::InvalidAttributeDefinition',
+  'We should get a proper exception if our attributes have attribute names';
+
+done_testing;

--- a/t/perlcriticrc
+++ b/t/perlcriticrc
@@ -3,10 +3,10 @@ severity = 4
 exclude = Freenode
 
 [TestingAndDebugging::RequireUseStrict]
-equivalent_modules = Test::Most MooseX::Extreme MooseX::Extreme::Role 
+equivalent_modules = Moose Test::Most MooseX::Extreme MooseX::Extreme::Role 
 
 [TestingAndDebugging::RequireUseWarnings]
-equivalent_modules = Test::Most MooseX::Extreme MooseX::Extreme::Role 
+equivalent_modules = Moose Test::Most MooseX::Extreme MooseX::Extreme::Role 
 
 [TestingAndDebugging::ProhibitNoWarnings]
 allow = experimental::signatures experimental::postderef


### PR DESCRIPTION
Found an invalid attribute definition, so we no longer allow those. Also started using exceptions.