### PR TITLE
Force minimum version of Type::Tiny and friends

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,6 +1,6 @@
 # Thanks, Gabor! https://perlmaven.com/setup-github-actions
 
-name: CI Dzil
+name: linux
  
 on:
     push:

--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@ Revision history for MooseX-Extended
 
 {{$NEXT}}
 
+          - Assert a minimum version of various Type:: modules due to CPAN
+            test failures from old versions released eight years ago!
+
 0.04      2022-05-25 10:41:10 CEST
           - Moved critic and tidy tests to xt/author to prevent false
             negatives on CPAN testers

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ MooseX::Extended - Extend Moose with safe defaults and useful features
 
 # VERSION
 
-version 0.04
+version 0.05
 
 # SYNOPSIS
 

--- a/dist.ini
+++ b/dist.ini
@@ -23,6 +23,16 @@ homepage                                         = https://github.com/Ovid/moose
 
 [AutoPrereqs]
 
+; Windows test failures were caused by having version of Type::Tiny and
+; friends which were released in 2014!
+[Prereqs]
+Type::Library          = 1.012004
+Type::Params           = 1.012004
+Type::Utils            = 1.012004
+Types::Common::Numeric = 1.012004
+Types::Common::String  = 1.012004
+Types::Standard        = 1.012004
+
 [CPANFile]
 
 [Git::Contributors]


### PR DESCRIPTION
Multiple [test failures on Windows](http://matrix.cpantesters.org/?dist=MooseX-Extended+0.04) all appear related to them having versions of Type::Tiny released back in 2014! So this PR asserts a minimum version.