### PR TITLE
WIP: Allow optional features via "includes"

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,8 +5,6 @@ name: linux
 on:
     push:
         branches: '*'
-    pull_request:
-        branches: '*'
     schedule:
         - cron: '42 5 * * 0'
  

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -35,5 +35,5 @@ jobs:
       - name: Run tests
         run: |
           dzil authordeps --missing | cpanm --notest
-          dzil listdeps --author --suggests | cpanm --notest
+          dzil listdeps --author --missing | cpanm --notest
           dzil test --author --release

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -35,5 +35,5 @@ jobs:
       - name: Run tests
         run: |
           dzil authordeps --missing | cpanm --notest
-          dzil listdeps --author --missing | cpanm --notest
+          dzil listdeps --author --suggests | cpanm --notest
           dzil test --author --release

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,6 +5,8 @@ name: linux
 on:
     push:
         branches: '*'
+#    pull_request:
+#        branches: '*'
     schedule:
         - cron: '42 5 * * 0'
  
@@ -23,6 +25,7 @@ jobs:
           - '5.30'
           - '5.32'
           - '5.34'
+          - '5.36'
           - 'latest'
     container:
       image: perldocker/perl-tester:${{ matrix.perl-version }}     # https://hub.docker.com/r/perldocker/perl-tester

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,8 @@ allows configuration via import lists:
         types    => [qw/HashRef ArrayRef/],
         excludes => [qw/StrictConstructor/];
 
-We may add a new `includes` feature if a change:
+If you wish to extend `MooseX::Extended`, please use the C<includes> flag if
+the code:
 
 * Does not backport to `v5.20.0`
 * Breaks existing `MooseX::Extended` code
@@ -37,7 +38,4 @@ We may add a new `includes` feature if a change:
 
 For example:
 
-    use MooseX::Extended includes => [qw/some_new_feature/];
-
-This is not yet implemented. The key idea here is that we want to be safe and
-not break existing code.
+    use MooseX::Extended includes => [qw/multi/];

--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for MooseX-Extended
 
 {{$NEXT}}
 
+          - Add optional multimethod support
           - We no longer use @_ inside signatured subs
 
 0.10      2022-05-31 22:26:34 CEST

--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for MooseX-Extended
 
 {{$NEXT}}
 
+          - Linux CI now includes v.5.36.0
           - Add optional multimethod support
           - We no longer use @_ inside signatured subs
 

--- a/README.md
+++ b/README.md
@@ -303,6 +303,50 @@ This also applies to various attributes which allow method names, such as
 
 Trying to pass a defined `init_arg` to `field` will also this exception.
 
+# OPTIONAL FEATURES
+
+By default, [MooseX::Extended](https://metacpan.org/pod/MooseX%3A%3AExtended) tries to be relatively conservative. However,
+you might want to turn it up to 11. There are optional features you can use
+for this. They're turned by the `includes` flag:
+
+## `multi`
+
+```perl
+package My::Multi::Role {
+    use MooseX::Extended::Role includes => [qw/multi/];
+
+    multi sub point ( $self, $x, $y ) {
+        return My::Point->new( x => $x, y => $y );
+    }
+    multi sub point ( $self, $x, $y, $z ) {
+        return My::Point::3D->new( x => $x, y => $y, z => $z );
+    }
+}
+```
+
+`multi` allows you to provide multiple method (or subroutine) bodies with the
+same name. We use [Syntax::Keyword::MultiSub](https://metacpan.org/pod/Syntax%3A%3AKeyword%3A%3AMultiSub) to implement this, so see that module
+for caveats.
+
+It's quite possible to define multi subs that are ambiguous:
+
+```perl
+package Foo {
+    use MooseX::Extended includes => [qw/multi/];
+
+    multi sub foo ($self, @bar) { return '@bar' }
+    multi sub foo ($self, $bar) { return '$bar' }
+}
+
+say +Foo->new->foo(1);
+say +Foo->new->foo(1,2,3);
+```
+
+Both of the above will print the string `@bar`. The second definition of
+`foo` is effectively lost.
+
+`multi` is available for Perl versions 5.26 or higher.
+
 # DEBUGGER SUPPORT
 
 When running [MooseX::Extended](https://metacpan.org/pod/MooseX%3A%3AExtended) under the debugger, there are some

--- a/README.md
+++ b/README.md
@@ -196,6 +196,30 @@ problem. You can exclude the following:
 
     Excluding this will require your module to end in a true value.
 
+## `includes`
+
+Some experimental features are useful, but might not be quite what you want.
+
+- `multi`
+
+    ```perl
+    use MooseX::Extended includes => [qw/multi/];
+
+    multi sub foo ($self, $x)      { ... }
+    multi sub foo ($self, $x, $y ) { ... }
+    ```
+
+    Allows you to redeclare a method (or subroutine) and the dispatch will use the number
+    of arguments to determine which subroutine to use. Note that "slurpy" arguments such as
+    arrays or hashes will take precedence over scalars:
+
+    ```perl
+    multi sub foo ($self, @x) { ... }
+    multi sub foo ($self, $x) { ... } # will never be called
+    ```
+
+    Only available on Perl v5.26.0 or higher. Requires [Syntax::Keyword::MultiSub](https://metacpan.org/pod/Syntax%3A%3AKeyword%3A%3AMultiSub).
+
 # IMMUTABILITY
 
 ## Making Your Class Immutable

--- a/dist.ini
+++ b/dist.ini
@@ -33,6 +33,9 @@ true                = 1.0.2                               ; minimum safe version
 Perl::Critic::Policy::Moose::ProhibitMultipleWiths = 0    ; for xt tests
 Perl::Critic::Policy::Moose::RequireMakeImmutable  = 0    ; for xt tests
 
+[Prereqs / RuntimeSuggests]
+Syntax::Keyword::MultiSub = 0.02
+
 [CPANFile]
 
 [Git::Contributors]

--- a/lib/MooseX/Extended.pm
+++ b/lib/MooseX/Extended.pm
@@ -19,6 +19,7 @@ use MooseX::Extended::Core qw(
   _debug
   _enabled_features
   _disabled_warnings
+  _apply_optional_features
 );
 use feature _enabled_features();
 no warnings _disabled_warnings();
@@ -131,18 +132,6 @@ sub init_meta ( $class, %params ) {
 
     _apply_default_features( $config, $for_class );
     _apply_optional_features( $config, $for_class );
-}
-
-sub _apply_optional_features ( $config, $for_class ) {
-    if ( $config->{includes}{multi} ) {
-        if ( $^V && $^V lt v5.26.0 ) {
-            croak("multi subs not supported in Perl version less than v5.26.0. You have $^V");
-        }
-
-        # don't trap the error. Let it bubble up.
-        load Syntax::Keyword::MultiSub;
-        Syntax::Keyword::MultiSub->import::into($for_class);
-    }
 }
 
 sub _apply_default_features ( $config, $for_class ) {

--- a/lib/MooseX/Extended.pm
+++ b/lib/MooseX/Extended.pm
@@ -17,6 +17,7 @@ use MooseX::Extended::Core qw(
   field
   param
   _debug
+  _default_import_list
   _enabled_features
   _disabled_warnings
   _apply_optional_features
@@ -43,12 +44,11 @@ my %CONFIG_FOR;
 sub import {
 
     # don' use signatures for this import because we need @_ later. @_ is
-    # intended to be removed for singatures subs.
+    # intended to be removed for subs with signature
     my ( $class, %args ) = @_;
     my ( $package, $filename, $line ) = caller;
     state $check = compile_named(
-        debug    => Optional [Bool],
-        types    => Optional [ ArrayRef [NonEmptyStr] ],
+        _default_import_list(),
         excludes => Optional [
             ArrayRef [
                 Enum [
@@ -59,15 +59,6 @@ sub import {
                       carp
                       immutable
                       true
-                      /
-                ]
-            ]
-        ],
-        includes => Optional [
-            ArrayRef [
-                Enum [
-                    qw/
-                      multi
                       /
                 ]
             ]

--- a/lib/MooseX/Extended.pm
+++ b/lib/MooseX/Extended.pm
@@ -354,6 +354,30 @@ Excluding this will require your module to end in a true value.
 
 =back
 
+=head2 C<includes>
+
+Some experimental features are useful, but might not be quite what you want.
+
+=over 4
+
+=item * C<multi>
+
+    use MooseX::Extended includes => [qw/multi/];
+
+    multi sub foo ($self, $x)      { ... }
+    multi sub foo ($self, $x, $y ) { ... }
+
+Allows you to redeclare a method (or subroutine) and the dispatch will use the number
+of arguments to determine which subroutine to use. Note that "slurpy" arguments such as
+arrays or hashes will take precedence over scalars:
+
+    multi sub foo ($self, @x) { ... }
+    multi sub foo ($self, $x) { ... } # will never be called
+
+Only available on Perl v5.26.0 or higher. Requires L<Syntax::Keyword::MultiSub>.
+
+=back
+
 =head1 IMMUTABILITY
 
 =head2 Making Your Class Immutable

--- a/lib/MooseX/Extended.pm
+++ b/lib/MooseX/Extended.pm
@@ -184,7 +184,7 @@ sub _apply_default_features ( $config, $for_class ) {
 }
 1;
 
-    __END__
+__END__
 
 =head1 SYNOPSIS
 
@@ -452,6 +452,46 @@ This also applies to various attributes which allow method names, such as
 C<clone>, C<builder>, C<clearer>, C<writer>, C<reader>, and C<predicate>.
 
 Trying to pass a defined C<init_arg> to C<field> will also this exception.
+
+=head1 OPTIONAL FEATURES
+
+By default, L<MooseX::Extended> tries to be relatively conservative. However,
+you might want to turn it up to 11. There are optional features you can use
+for this. They're turned by the C<includes> flag:
+
+=head2 C<multi>
+
+    package My::Multi::Role {
+        use MooseX::Extended::Role includes => [qw/multi/];
+
+        multi sub point ( $self, $x, $y ) {
+            return My::Point->new( x => $x, y => $y );
+        }
+        multi sub point ( $self, $x, $y, $z ) {
+            return My::Point::3D->new( x => $x, y => $y, z => $z );
+        }
+    }
+
+C<multi> allows you to provide multiple method (or subroutine) bodies with the
+same name. We use L<Syntax::Keyword::MultiSub> to implement this, so see that module
+for caveats.
+
+It's quite possible to define multi subs that are ambiguous:
+
+    package Foo {
+        use MooseX::Extended includes => [qw/multi/];
+
+        multi sub foo ($self, @bar) { return '@bar' }
+        multi sub foo ($self, $bar) { return '$bar' }
+    }
+
+    say +Foo->new->foo(1);
+    say +Foo->new->foo(1,2,3);
+
+Both of the above will print the string C<@bar>. The second definition of
+C<foo> is effectively lost.
+
+C<multi> is available for Perl versions 5.26 or higher.
 
 =head1 DEBUGGER SUPPORT
 

--- a/lib/MooseX/Extended/Core.pm
+++ b/lib/MooseX/Extended/Core.pm
@@ -64,10 +64,6 @@ sub _apply_optional_features ( $config, $for_class ) {
             croak("multi subs not supported in Perl version less than v5.26.0. You have $^V");
         }
 
-        use Data::Dumper;
-        say STDERR Dumper($config);
-        say STDERR Dumper($for_class);
-
         # don't trap the error. Let it bubble up.
         load Syntax::Keyword::MultiSub;
         Syntax::Keyword::MultiSub->import::into($for_class);

--- a/lib/MooseX/Extended/Core.pm
+++ b/lib/MooseX/Extended/Core.pm
@@ -9,6 +9,13 @@ use Moose::Util qw(
   add_method_modifier
   throw_exception
 );
+use MooseX::Extended::Types qw(
+  ArrayRef
+  Bool
+  Enum
+  NonEmptyStr
+  Optional
+);
 use Module::Load 'load';
 use feature qw(signatures postderef);
 no warnings qw(experimental::signatures experimental::postderef);
@@ -28,11 +35,28 @@ our @EXPORT_OK = qw(
   _debug
   _enabled_features
   _disabled_warnings
+  _default_import_list
   _apply_optional_features
 );
 
 sub _enabled_features  {qw/signatures postderef postderef_qq :5.20/}             # internal use only
 sub _disabled_warnings {qw/experimental::signatures experimental::postderef/}    # internal use only
+
+sub _default_import_list () {
+    return (
+        debug    => Optional [Bool],
+        types    => Optional [ ArrayRef [NonEmptyStr] ],
+        includes => Optional [
+            ArrayRef [
+                Enum [
+                    qw/
+                      multi
+                      /
+                ]
+            ]
+        ]
+    );
+}
 
 sub _apply_optional_features ( $config, $for_class ) {
     if ( $config->{includes}{multi} ) {

--- a/lib/MooseX/Extended/Core.pm
+++ b/lib/MooseX/Extended/Core.pm
@@ -61,10 +61,12 @@ sub _default_import_list () {
 sub _apply_optional_features ( $config, $for_class ) {
     if ( $config->{includes}{multi} ) {
         if ( $^V && $^V lt v5.26.0 ) {
-            explain $config;
-            explain $for_class;
             croak("multi subs not supported in Perl version less than v5.26.0. You have $^V");
         }
+
+        use Data : Dumper;
+        say STDERR Dumper($config);
+        say STDERR Dumper($for_class);
 
         # don't trap the error. Let it bubble up.
         load Syntax::Keyword::MultiSub;

--- a/lib/MooseX/Extended/Core.pm
+++ b/lib/MooseX/Extended/Core.pm
@@ -61,6 +61,8 @@ sub _default_import_list () {
 sub _apply_optional_features ( $config, $for_class ) {
     if ( $config->{includes}{multi} ) {
         if ( $^V && $^V lt v5.26.0 ) {
+            explain $config;
+            explain $for_class;
             croak("multi subs not supported in Perl version less than v5.26.0. You have $^V");
         }
 

--- a/lib/MooseX/Extended/Core.pm
+++ b/lib/MooseX/Extended/Core.pm
@@ -9,6 +9,7 @@ use Moose::Util qw(
   add_method_modifier
   throw_exception
 );
+use Module::Load 'load';
 use feature qw(signatures postderef);
 no warnings qw(experimental::signatures experimental::postderef);
 
@@ -27,10 +28,23 @@ our @EXPORT_OK = qw(
   _debug
   _enabled_features
   _disabled_warnings
+  _apply_optional_features
 );
 
 sub _enabled_features  {qw/signatures postderef postderef_qq :5.20/}             # internal use only
 sub _disabled_warnings {qw/experimental::signatures experimental::postderef/}    # internal use only
+
+sub _apply_optional_features ( $config, $for_class ) {
+    if ( $config->{includes}{multi} ) {
+        if ( $^V && $^V lt v5.26.0 ) {
+            croak("multi subs not supported in Perl version less than v5.26.0. You have $^V");
+        }
+
+        # don't trap the error. Let it bubble up.
+        load Syntax::Keyword::MultiSub;
+        Syntax::Keyword::MultiSub->import::into($for_class);
+    }
+}
 
 sub param ( $meta, $name, %opt_for ) {
     $opt_for{is}       //= 'ro';

--- a/lib/MooseX/Extended/Core.pm
+++ b/lib/MooseX/Extended/Core.pm
@@ -64,7 +64,7 @@ sub _apply_optional_features ( $config, $for_class ) {
             croak("multi subs not supported in Perl version less than v5.26.0. You have $^V");
         }
 
-        use Data : Dumper;
+        use Data::Dumper;
         say STDERR Dumper($config);
         say STDERR Dumper($for_class);
 

--- a/lib/MooseX/Extended/Role.pm
+++ b/lib/MooseX/Extended/Role.pm
@@ -209,6 +209,30 @@ Excluding this will require your module to end in a true value.
 
 =back
 
+=head2 C<includes>
+
+Some experimental features are useful, but might not be quite what you want.
+
+=over 4
+
+=item * C<multi>
+
+    use MooseX::Extended::Role includes => [qw/multi/];
+
+    multi sub foo ($self, $x)      { ... }
+    multi sub foo ($self, $x, $y ) { ... }
+
+Allows you to redeclare a method (or subroutine) and the dispatch will use the number
+of arguments to determine which subroutine to use. Note that "slurpy" arguments such as
+arrays or hashes will take precedence over scalars:
+
+    multi sub foo ($self, @x) { ... }
+    multi sub foo ($self, $x) { ... } # will never be called
+
+Only available on Perl v5.26.0 or higher. Requires L<Syntax::Keyword::MultiSub>.
+
+=back
+
 =head1 IDENTICAL METHOD NAMES IN CLASSES AND ROLES
 
 In L<Moose> if a class defines a method of the name as the method of a role

--- a/lib/MooseX/Extended/Role.pm
+++ b/lib/MooseX/Extended/Role.pm
@@ -10,6 +10,7 @@ use MooseX::Extended::Core qw(
   field
   param
   _debug
+  _default_import_list
   _enabled_features
   _disabled_warnings
   _apply_optional_features
@@ -41,8 +42,7 @@ sub import {
     my ( $class, %args ) = @_;
     my ( $package, $filename, $line ) = caller;
     state $check = compile_named(
-        debug    => Optional [Bool],
-        types    => Optional [ ArrayRef [NonEmptyStr] ],
+        _default_import_list(),
         excludes => Optional [
             ArrayRef [
                 Enum [
@@ -51,15 +51,6 @@ sub import {
                       autoclean
                       carp
                       true
-                      /
-                ]
-            ]
-        ],
-        includes => Optional [
-            ArrayRef [
-                Enum [
-                    qw/
-                      multi
                       /
                 ]
             ]

--- a/t/multimethods.t
+++ b/t/multimethods.t
@@ -1,0 +1,47 @@
+#!/usr/bin/env perl
+
+use lib 'lib';
+use Test::Most;
+
+package My::Point {
+    use MooseX::Extended types => [qw/Num/];
+    param [ 'x', 'y' ] => ( isa => Num );
+}
+
+package My::Point::3D {
+    use MooseX::Extended types => [qw/Num/];
+    extends 'My::Point';
+    param 'z' => ( isa => Num );
+}
+
+package My::Multi {
+    use MooseX::Extended includes => [qw/multi/];
+
+    multi sub point ( $self, $x, $y ) {
+        return My::Point->new( x => $x, y => $y );
+    }
+    multi sub point ( $self, $x, $y, $z ) {
+        return My::Point::3D->new( x => $x, y => $y, z => $z );
+    }
+}
+
+ok my $multi = My::Multi->new, 'We should be allowed to load a class with multimethods';
+
+subtest '2d point' => sub {
+    ok my $point = $multi->point( 3, 4 ), 'We can fetch a 2d point';
+    ok $point->isa('My::Point'),          '... and it should be the correct class';
+    ok !$point->isa('My::Point::3D'),     '... and definitely not the wrong class';
+    is $point->x, 3, '... with the correct x';
+    is $point->y, 4, '... and the correct y';
+    ok !$point->can('z'), '... and it does not have a z attribute';
+};
+subtest '3d point' => sub {
+    ok my $point = $multi->point( 5, 6, 7 ), 'We can fetch a 3d point';
+    ok $point->isa('My::Point'),          '... and it should be the correct class';
+    ok !$point->isa('My::Point::3D'),     '... and definitely not the wrong class';
+    is $point->x, 3, '... with the correct x';
+    is $point->y, 4, '... and the correct y';
+    ok !$point->can('z'), '... and it does not have a z attribute';
+};
+
+done_testing;

--- a/t/multimethods.t
+++ b/t/multimethods.t
@@ -1,7 +1,9 @@
 #!/usr/bin/env perl
 
-use lib 'lib';
 use Test::Most;
+if ( $^V && $^V lt v5.26.0 ) {
+    plan skip_all => 'Version v5.26.0 or greater required for multimethod support';
+}
 
 package My::Point {
     use MooseX::Extended types => [qw/Num/];
@@ -25,23 +27,54 @@ package My::Multi {
     }
 }
 
-ok my $multi = My::Multi->new, 'We should be allowed to load a class with multimethods';
+package My::Multi::Role {
+    use MooseX::Extended::Role includes => [qw/multi/];
 
-subtest '2d point' => sub {
-    ok my $point = $multi->point( 3, 4 ), 'We can fetch a 2d point';
-    ok $point->isa('My::Point'),          '... and it should be the correct class';
-    ok !$point->isa('My::Point::3D'),     '... and definitely not the wrong class';
-    is $point->x, 3, '... with the correct x';
-    is $point->y, 4, '... and the correct y';
-    ok !$point->can('z'), '... and it does not have a z attribute';
-};
-subtest '3d point' => sub {
-    ok my $point = $multi->point( 5, 6, 7 ), 'We can fetch a 3d point';
-    ok $point->isa('My::Point'),          '... and it should be the correct class';
-    ok !$point->isa('My::Point::3D'),     '... and definitely not the wrong class';
-    is $point->x, 3, '... with the correct x';
-    is $point->y, 4, '... and the correct y';
-    ok !$point->can('z'), '... and it does not have a z attribute';
-};
+    multi sub point ( $self, $x, $y ) {
+        return My::Point->new( x => $x, y => $y );
+    }
+    multi sub point ( $self, $x, $y, $z ) {
+        return My::Point::3D->new( x => $x, y => $y, z => $z );
+    }
+}
+
+package My::Class::Consuming::The::Role {
+    use MooseX::Extended;
+    with 'My::Multi::Role';
+}
+
+my %cases = (
+    classes => 'My::Multi',
+    roles   => 'My::Class::Consuming::The::Role',
+);
+
+while ( my ( $name, $class ) = each %cases ) {
+    subtest "Multi in classes" => sub {
+        ok my $multi = $class->new, "We should be allowed to load $name with multimethods";
+
+        subtest '2d point' => sub {
+            ok my $point = $multi->point( 3, 4 ), 'We can fetch a 2d point';
+            ok $point->isa('My::Point'),          '... and it should be the correct class';
+            ok !$point->isa('My::Point::3D'),     '... and definitely not the wrong class';
+            is $point->x, 3, '... with the correct x';
+            is $point->y, 4, '... and the correct y';
+            ok !$point->can('z'), '... and it does not have a z attribute';
+        };
+
+        subtest '3d point' => sub {
+            ok my $point = $multi->point( 5, 6, 7 ), 'We can fetch a 3d point';
+            ok $point->isa('My::Point'),             '... and it should be the correct class';
+            ok $point->isa('My::Point::3D'),         '... and t should be the corect class';
+            is $point->x, 5, '... with the correct x';
+            is $point->y, 6, '... and the correct y';
+            is $point->z, 7, '... and the correct z';
+        };
+
+        explain 'We would need to defind `multi sub point( $self, $x );` for this to work';
+        throws_ok { $multi->point(1); }
+        qr/Unable to find a function body for a call to .*? having 2 arguments/,
+          'Multimethods whose arguments do not match will fail';
+    };
+}
 
 done_testing;

--- a/t/multimethods.t
+++ b/t/multimethods.t
@@ -2,16 +2,22 @@
 
 use Test::Most;
 use Module::Load 'load';
-if ( $^V && $^V lt v5.26.0 ) {
-    plan skip_all => 'Version v5.26.0 or greater required for multimethod support';
+
+BEGIN {
+    # do this in a BEGIN  block to exit early. Otherwise, the rest of
+    # the code won't even compile if we don't have Syntax::Keyword::MultiSub
+    # installed.
+    if ( $^V && $^V lt v5.26.0 ) {
+        plan skip_all => 'Version v5.26.0 or greater required for multimethod support';
+    }
+    eval {
+        load Syntax::Keyword::MultiSub;
+        1;
+    } or do {
+        my $error = $@ || "<unknown error>";
+        plan skip_all => "Could not load Syntax::Keyword::MultiSub: $error";
+    };
 }
-eval {
-    load Syntax::Keyword::MultiSub;
-    1;
-} or do {
-    my $error = $@ || "<unknown error>";
-    plan skip_all => "Could not load Syntax::Keyword::MultiSub: $error";
-};
 
 package My::Point {
     use MooseX::Extended types => [qw/Num/];

--- a/t/multimethods.t
+++ b/t/multimethods.t
@@ -1,9 +1,17 @@
 #!/usr/bin/env perl
 
 use Test::Most;
+use Module::Load 'load';
 if ( $^V && $^V lt v5.26.0 ) {
     plan skip_all => 'Version v5.26.0 or greater required for multimethod support';
 }
+eval {
+    load Syntax::Keyword::MultiSub;
+    1;
+} or do {
+    my $error = $@ || "<unknown error>";
+    plan skip_all => "Could not load Syntax::Keyword::MultiSub: $error";
+};
 
 package My::Point {
     use MooseX::Extended types => [qw/Num/];


### PR DESCRIPTION
Currently, only multimethods:

```perl
    use MooseX::Extended includes => [qw/multi/];
```