### PR TITLE
Customization

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for MooseX-Extended
 
 {{$NEXT}}
 
+          - Add MooseX::Extended::Custom (create your own Moose)
           - Add optional async/await support
           - Linux CI now includes v.5.36.0
           - Add optional multimethod support

--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for MooseX-Extended
 
 {{$NEXT}}
 
+          - Add MooseX::Extended::Role::Custom (create your own Moose::Role)
           - Add MooseX::Extended::Custom (create your own Moose)
           - Add optional async/await support
           - Linux CI now includes v.5.36.0

--- a/lib/MooseX/Extended.pm
+++ b/lib/MooseX/Extended.pm
@@ -186,7 +186,6 @@ sub _apply_default_features ( $config, $for_class ) {
 
     feature->import( _enabled_features() );
     warnings->unimport(_disabled_warnings);
-
 }
 1;
 

--- a/lib/MooseX/Extended.pm
+++ b/lib/MooseX/Extended.pm
@@ -31,22 +31,17 @@ no warnings _disabled_warnings();
 
 our $VERSION = '0.11';
 
-my ( $import, undef, $init_meta ) = Moose::Exporter->setup_import_methods(
-    with_meta => [ 'field', 'param' ],
-    install   => [qw/unimport/],
-    also      => ['Moose'],
-);
-
 # Should this be in the metaclass? It feels like it should, but
 # the MOP really doesn't support these edge cases.
 my %CONFIG_FOR;
 
 sub import {
 
-    # don' use signatures for this import because we need @_ later. @_ is
+    # don't use signatures for this import because we need @_ later. @_ is
     # intended to be removed for subs with signature
     my ( $class, %args ) = @_;
     my ( $package, $filename, $line ) = caller;
+
     state $check = compile_named(
         _default_import_list(),
         excludes => Optional [
@@ -96,6 +91,12 @@ END
     }
 
     $CONFIG_FOR{$package} = \%args;
+
+    my ( $import, undef, undef ) = Moose::Exporter->setup_import_methods(
+        with_meta => [ 'field', 'param' ],
+        install   => [qw/unimport/],
+        also      => ['Moose'],
+    );
 
     @_ = $class;    # anything else and $import blows up
     goto $import;

--- a/lib/MooseX/Extended.pm
+++ b/lib/MooseX/Extended.pm
@@ -44,9 +44,9 @@ sub import {
 
 # Internal method setting up exports. No public
 # documentation by design
-sub init_meta ($class, %params) {
+sub init_meta ( $class, %params ) {
     Moose->init_meta(%params);
-    _our_init_meta($class, \&_apply_default_features, %params);
+    _our_init_meta( $class, \&_apply_default_features, %params );
 }
 
 # XXX we don't actually use the $params here, even though we need it for

--- a/lib/MooseX/Extended.pm
+++ b/lib/MooseX/Extended.pm
@@ -21,7 +21,7 @@ use MooseX::Extended::Core qw(
   _disabled_warnings
   _apply_optional_features
   _our_import
-  config_for
+  _config_for
 );
 use feature _enabled_features();
 no warnings _disabled_warnings();
@@ -47,7 +47,7 @@ sub init_meta ( $class, %params ) {
     my $for_class = $params{for_class};
     Moose->init_meta(%params);
 
-    my $config = config_for($for_class);
+    my $config = _config_for($for_class);
 
     if ( $config->{debug} ) {
         $MooseX::Extended::Debug = $config->{debug};

--- a/lib/MooseX/Extended/Core.pm
+++ b/lib/MooseX/Extended/Core.pm
@@ -59,9 +59,9 @@ sub _our_import {
 
     # don't use signatures for this import because we need @_ later. @_ is
     # intended to be removed for subs with signature
-    my ($class, $import, %args) = @_;
+    my ( $class, $import, %args ) = @_;
     $args{call_level} //= 0;
-    my ( $package, $filename, $line ) = caller( $args{call_level} +1 );
+    my ( $package, $filename, $line ) = caller( $args{call_level} + 1 );
     my $target_class = $args{for_class} // $package;
 
     state $check = {
@@ -104,7 +104,7 @@ END
 
     $CONFIG_FOR{$target_class} = \%args;
 
-    # Moose::Exporter uses Sub::Exporter to handle exporting, so it accepts an 
+    # Moose::Exporter uses Sub::Exporter to handle exporting, so it accepts an
     # { into =>> $target_class } to say where we're exporting this to. This is
     # used by our ::Custom modules to let people define their own versions
     @_ = ( $class, { into => $target_class } );    # anything else and $import blows up

--- a/lib/MooseX/Extended/Core.pm
+++ b/lib/MooseX/Extended/Core.pm
@@ -41,7 +41,7 @@ our @EXPORT_OK = qw(
   _apply_optional_features
   _role_excludes
   _class_excludes
-  config_for
+  _config_for
 );
 
 sub _enabled_features  {qw/signatures postderef postderef_qq :5.20/}             # internal use only
@@ -51,7 +51,7 @@ sub _disabled_warnings {qw/experimental::signatures experimental::postderef/}   
 # the MOP really doesn't support these edge cases.
 my %CONFIG_FOR;
 
-sub config_for ($package) {
+sub _config_for ($package) {
     return $CONFIG_FOR{$package};
 }
 

--- a/lib/MooseX/Extended/Core.pm
+++ b/lib/MooseX/Extended/Core.pm
@@ -44,9 +44,11 @@ sub _disabled_warnings {qw/experimental::signatures experimental::postderef/}   
 
 sub _default_import_list () {
     return (
-        debug    => Optional [Bool],
-        types    => Optional [ ArrayRef [NonEmptyStr] ],
-        includes => Optional [
+        call_level => Optional [ Enum [ 1, 0 ] ],
+        debug      => Optional [Bool],
+        for_class  => Optional [NonEmptyStr],
+        types      => Optional [ ArrayRef [NonEmptyStr] ],
+        includes   => Optional [
             ArrayRef [
                 Enum [
                     qw/

--- a/lib/MooseX/Extended/Core.pm
+++ b/lib/MooseX/Extended/Core.pm
@@ -10,6 +10,7 @@ use Moose::Util qw(
   throw_exception
 );
 use MooseX::Extended::Types qw(
+  compile_named
   ArrayRef
   Bool
   Enum
@@ -32,23 +33,142 @@ our $VERSION = '0.11';
 our @EXPORT_OK = qw(
   field
   param
+  _our_import
   _debug
   _enabled_features
   _disabled_warnings
   _default_import_list
   _apply_optional_features
+  _role_excludes
+  _class_excludes
+  config_for
 );
 
 sub _enabled_features  {qw/signatures postderef postderef_qq :5.20/}             # internal use only
 sub _disabled_warnings {qw/experimental::signatures experimental::postderef/}    # internal use only
 
+# Should this be in the metaclass? It feels like it should, but
+# the MOP really doesn't support these edge cases.
+my %CONFIG_FOR;
+
+sub config_for ($package) {
+    return $CONFIG_FOR{$package};
+}
+
+sub _our_import {
+
+    # don't use signatures for this import because we need @_ later. @_ is
+    # intended to be removed for subs with signature
+    my ($class, $import, %args) = @_;
+    $args{call_level} //= 0;
+    my ( $package, $filename, $line ) = caller( $args{call_level} +1 );
+    my $target_class = $args{for_class} // $package;
+
+    state $check = {
+        class => compile_named( _default_import_list(), _class_excludes() ),
+        role  => compile_named( _default_import_list(), _role_excludes() )
+    };
+    eval {
+        $check->{ $args{_import_type} }->(%args);
+        1;
+    } or do {
+
+        # Not sure what's happening, but if we don't use the eval to trap the
+        # error, it gets swallowed and we simply get:
+        #
+        # BEGIN failed--compilation aborted at ...
+        #
+        # Also, don't use $target_class here because if it's different from
+        # $package, the filename and line number won't match
+        my $error = $@;
+        Carp::carp(<<"END");
+Error:    Invalid import list to $class.
+Package:  $package
+Filename: $filename
+Line:     $line
+Details:  $error
+END
+        throw_exception(
+            'InvalidImportList',
+            class_name           => $package,
+            moosex_extended_type => __PACKAGE__,
+            line_number          => $line,
+            messsage             => $error,
+        );
+    };
+
+    # remap the arrays to hashes for easy lookup
+    foreach my $features (qw/includes excludes/) {
+        $args{$features} = { map { $_ => 1 } $args{$features}->@* };
+    }
+
+    $CONFIG_FOR{$target_class} = \%args;
+
+    # Moose::Exporter uses Sub::Exporter to handle exporting, so it accepts an 
+    # { into =>> $target_class } to say where we're exporting this to. This is
+    # used by our ::Custom modules to let people define their own versions
+    @_ = ( $class, { into => $target_class } );    # anything else and $import blows up
+    goto $import;
+}
+
+sub _class_setup_import_methods () {
+    return (
+        with_meta => [ 'field', 'param' ],
+        install   => [qw/unimport/],
+        also      => ['Moose'],
+    );
+}
+
+sub _role_setup_import_methods () {
+    return (
+        with_meta => [ 'field', 'param' ],
+    );
+}
+
+sub _role_excludes () {
+    return (
+        excludes => Optional [
+            ArrayRef [
+                Enum [
+                    qw/
+                      WarnOnConflict
+                      autoclean
+                      carp
+                      true
+                      /
+                ]
+            ]
+        ]
+    );
+}
+
+sub _class_excludes () {
+    return (
+        excludes => Optional [
+            ArrayRef [
+                Enum [
+                    qw/
+                      StrictConstructor
+                      autoclean
+                      c3
+                      carp
+                      immutable
+                      true
+                      /
+                ]
+            ]
+        ]
+    );
+}
+
 sub _default_import_list () {
     return (
-        call_level => Optional [ Enum [ 1, 0 ] ],
-        debug      => Optional [Bool],
-        for_class  => Optional [NonEmptyStr],
-        types      => Optional [ ArrayRef [NonEmptyStr] ],
-        includes   => Optional [
+        call_level   => Optional [ Enum [ 1, 0 ] ],
+        debug        => Optional [Bool],
+        for_class    => Optional [NonEmptyStr],
+        types        => Optional [ ArrayRef [NonEmptyStr] ],
+        _import_type => Enum [qw/class role/],
+        includes     => Optional [
             ArrayRef [
                 Enum [
                     qw/

--- a/lib/MooseX/Extended/Custom.pm
+++ b/lib/MooseX/Extended/Custom.pm
@@ -10,9 +10,10 @@ use MooseX::Extended::Core qw(
   _enabled_features
   _disabled_warnings
 );
+use MooseX::Extended ();
 use namespace::autoclean;
 
-use MooseX::Extended ();
+our $VERSION = '0.11';
 
 sub import {
     my $custom_moose = caller;    # this is our custom Moose definition

--- a/lib/MooseX/Extended/Custom.pm
+++ b/lib/MooseX/Extended/Custom.pm
@@ -1,0 +1,104 @@
+package MooseX::Extended::Custom;
+
+# ABSTRACT: Build a custom Moose, just for you.
+
+use 5.20.0;
+use strict;
+use warnings;
+use true;
+
+use MooseX::Extended ();
+
+sub import {
+    my $custom_moose = caller;    # this is our custom Moose definition
+    true->import::into($custom_moose);
+    strict->import::into($custom_moose);
+    warnings->import::into($custom_moose);
+}
+
+sub create {
+    my ( $class, %args ) = @_;
+    my $target_class = caller(1);    # this is the class consuming our custom Moose
+    MooseX::Extended->import(
+        %args,
+        call_level => 1,
+        for_class  => $target_class,
+    );
+}
+
+1;
+
+__END__
+
+=head1 SYNOPSIS
+
+Define your own version of L<MooseX::Extended>:
+
+    package My::Moose {
+        use MooseX::Extended::Custom;
+
+        sub import {
+            my ( $class, %args ) = @_;
+            MooseX::Extended::Custom->create(
+                excludes => [qw/ StrictConstructor c3 /],
+                includes => ['multi'],
+                %args    # you need this to allow customization of your customization
+            );
+        }
+    }
+
+    # no need for a true value
+
+And then use it:
+
+    package Some::Class {
+        use My::Moose types => [qw/ArrayRef Num/];
+
+        param numbers ( isa => ArrayRef[Num] );
+
+        multi sub foo ($self)       { ... }
+        multi sub foo ($self, $bar) { ... }
+    }
+
+=head1 DESCRIPTION
+
+I hate boilerplate, so let's get rid of it. Let's say you don't want L<namespace::autoclean> or
+C<carp>, but you do want C<multi>. Plus, you have custom versions of C<carp> and C<croak>:
+
+    package Some::Class {
+        use MooseX::Extended
+          excludes => [qw/ autoclean carp /],
+          includes => ['multi'];
+        use My::Carp q(carp croak);
+
+        ... my code here
+    }
+
+You probably get tired of typing that every time. Now you don't have to. 
+
+    package My::Moose {
+        use MooseX::Extended::Custom;
+        use My::Carp ();
+        use Import::Into;
+
+        sub import {
+            my ( $class, %args ) = @_;
+            my $target_class = caller;
+            MooseX::Extended::Custom->create(
+                excludes => [qw/ autoclean carp /],
+                includes => ['multi'],
+                %args    # you need this to allow customization of your customization
+            );
+            My::Carp->import::into($target_class, qw(carp croak));
+        }
+    }
+
+And then when you use C<My::Moose>, that's all set up for you.
+
+If you need to change this on a "per class" basis:
+
+    use My::Moose
+      excludes => ['carp'],
+      types    => [qw/ArrayRef Num/];
+
+The above changes your C<excludes> and adds C<types>, but doesn't change your C<includes>.

--- a/lib/MooseX/Extended/Role.pm
+++ b/lib/MooseX/Extended/Role.pm
@@ -10,11 +10,9 @@ use MooseX::Extended::Core qw(
   field
   param
   _debug
-  _default_import_list
   _enabled_features
   _disabled_warnings
   _apply_optional_features
-  _role_excludes
   _our_import
   _config_for
 );

--- a/lib/MooseX/Extended/Role.pm
+++ b/lib/MooseX/Extended/Role.pm
@@ -27,20 +27,17 @@ no warnings _disabled_warnings();
 
 our $VERSION = '0.11';
 
-my ( $import, undef, $init_meta ) = Moose::Exporter->setup_import_methods(
-    with_meta => [ 'field', 'param' ],
-);
-
 # Should this be in the metaclass? It feels like it should, but
 # the MOP really doesn't support these edge cases.
 my %CONFIG_FOR;
 
 sub import {
 
-    # don' use signatures for this import because we need @_ later. @_ is
+    # don't use signatures for this import because we need @_ later. @_ is
     # intended to be removed for singatures subs.
     my ( $class, %args ) = @_;
     my ( $package, $filename, $line ) = caller;
+
     state $check = compile_named(
         _default_import_list(),
         excludes => Optional [
@@ -88,6 +85,10 @@ END
     }
 
     $CONFIG_FOR{$package} = \%args;
+
+    my ( $import, undef, $init_meta ) = Moose::Exporter->setup_import_methods(
+        with_meta => [ 'field', 'param' ],
+    );
 
     @_ = $class;    # anything else and $import blows up
     goto $import;

--- a/lib/MooseX/Extended/Role.pm
+++ b/lib/MooseX/Extended/Role.pm
@@ -14,6 +14,7 @@ use MooseX::Extended::Core qw(
   _disabled_warnings
   _apply_optional_features
   _our_import
+  _our_init_meta
   _config_for
 );
 use MooseX::Role::WarnOnConflict ();
@@ -43,23 +44,7 @@ sub import {
 
 sub init_meta ( $class, %params ) {
     my $for_class = $params{for_class};
-
-    my $config = _config_for($for_class);
-
-    if ( $config->{debug} ) {
-        $MooseX::Extended::Debug = $config->{debug};
-    }
-
-    foreach my $feature (qw/includes excludes/) {
-        if ( exists $config->{$feature} ) {
-            foreach my $category ( sort keys $config->{$feature}->%* ) {
-                _debug("$for_class $feature '$category'");
-            }
-        }
-    }
-
-    _apply_default_features( $config, $for_class, \%params );
-    _apply_optional_features( $config, $for_class );
+    _our_init_meta( $class, \&_apply_default_features, %params );
     return $for_class->meta;
 }
 

--- a/lib/MooseX/Extended/Role.pm
+++ b/lib/MooseX/Extended/Role.pm
@@ -16,7 +16,7 @@ use MooseX::Extended::Core qw(
   _apply_optional_features
   _role_excludes
   _our_import
-  config_for
+  _config_for
 );
 use MooseX::Role::WarnOnConflict ();
 use Moose::Role;
@@ -46,7 +46,7 @@ sub import {
 sub init_meta ( $class, %params ) {
     my $for_class = $params{for_class};
 
-    my $config = config_for($for_class);
+    my $config = _config_for($for_class);
 
     if ( $config->{debug} ) {
         $MooseX::Extended::Debug = $config->{debug};

--- a/lib/MooseX/Extended/Role/Custom.pm
+++ b/lib/MooseX/Extended/Role/Custom.pm
@@ -1,6 +1,6 @@
-package MooseX::Extended::Custom;
+package MooseX::Extended::Role::Custom;
 
-# ABSTRACT: Build a custom Moose, just for you.
+# ABSTRACT: Build a custom Moose::Role, just for you.
 
 use 5.20.0;
 use strict;
@@ -12,7 +12,7 @@ use MooseX::Extended::Core qw(
 );
 use namespace::autoclean;
 
-use MooseX::Extended ();
+use MooseX::Extended::Role ();
 
 sub import {
     my $custom_moose = caller;    # this is our custom Moose definition
@@ -27,7 +27,7 @@ sub import {
 sub create {
     my ( $class, %args ) = @_;
     my $target_class = caller(1);    # this is the class consuming our custom Moose
-    MooseX::Extended->import(
+    MooseX::Extended::Role->import(
         %args,
         call_level => 1,
         for_class  => $target_class,
@@ -42,13 +42,13 @@ __END__
 
 Define your own version of L<MooseX::Extended>:
 
-    package My::Moose {
-        use MooseX::Extended::Custom;
+    package My::Moose::Role {
+        use MooseX::Extended::Role::Custom;
 
         sub import {
             my ( $class, %args ) = @_;
-            MooseX::Extended::Custom->create(
-                excludes => [qw/ StrictConstructor c3 /],
+            MooseX::Extended::Role::Custom->create(
+                excludes => [qw/ carp /],
                 includes => ['multi'],
                 %args    # you need this to allow customization of your customization
             );
@@ -59,10 +59,10 @@ Define your own version of L<MooseX::Extended>:
 
 And then use it:
 
-    package Some::Class {
-        use My::Moose types => [qw/ArrayRef Num/];
+    package Some::Class::Role {
+        use My::Moose::Role types => [qw/ArrayRef Num/];
 
-        param numbers ( isa => ArrayRef[Num] );
+        param numbers => ( isa => ArrayRef[Num] );
 
         multi sub foo ($self)       { ... }
         multi sub foo ($self, $bar) { ... }
@@ -70,12 +70,14 @@ And then use it:
 
 =head1 DESCRIPTION
 
-I hate boilerplate, so let's get rid of it. Let's say you don't want L<namespace::autoclean> or
-C<carp>, but you do want C<multi>. Plus, you have custom versions of C<carp> and C<croak>:
+I hate boilerplate, so let's get rid of it. Let's say you don't want warnings
+on classes implicitly overriding role methods, L<namespace::autoclean> or
+C<carp>, but you do want C<multi>. Plus, you have custom versions of C<carp>
+and C<croak>:
 
     package Some::Class {
         use MooseX::Extended
-          excludes => [qw/ autoclean carp /],
+          excludes => [qw/ WarnOnConflict autoclean carp /],
           includes => ['multi'];
         use My::Carp q(carp croak);
 

--- a/lib/MooseX/Extended/Role/Custom.pm
+++ b/lib/MooseX/Extended/Role/Custom.pm
@@ -10,9 +10,10 @@ use MooseX::Extended::Core qw(
   _enabled_features
   _disabled_warnings
 );
+use MooseX::Extended::Role ();
 use namespace::autoclean;
 
-use MooseX::Extended::Role ();
+our $VERSION = '0.11';
 
 sub import {
     my $custom_moose = caller;    # this is our custom Moose definition

--- a/t/custom.t
+++ b/t/custom.t
@@ -1,0 +1,83 @@
+#!/usr/bin/env perl
+
+use lib 't/lib';
+use MooseX::Extended::Tests;
+
+package My::Names {
+    use My::Moose types => [qw(compile Num NonEmptyStr Str PositiveInt ArrayRef)];
+    use List::Util 'sum';
+
+    param _name => ( isa => NonEmptyStr, init_arg => 'name' );
+    param title => ( isa => Str, required => 0, predicate => 1 );
+    field created => ( isa => PositiveInt, default => sub {time} );
+
+    sub name ($self) {
+        my $title = $self->title;
+        my $name  = $self->_name;
+        return $title ? "$title $name" : $name;
+    }
+
+    sub add ( $self, $args ) {
+        state $check = compile( ArrayRef [ Num, 1 ] );
+        ($args) = $check->($args);
+        return sum( $args->@* );
+    }
+
+    sub warnit ($self) {
+        carp("this is a warning");
+    }
+}
+
+subtest 'miscellaneous features' => sub {
+    SKIP: {
+        skip "Classes cannot be immutable while running under the debugger", 1 if $^P;
+        ok +My::Names->meta->is_immutable,
+          'We should be able to define an immutable class';
+    }
+    isnt mro::get_mro('My::Names'), 'c3', "... but we can exclude the C3 mro if we want";
+
+    ok my $instance = My::Names->new(
+        name              => 'Bob',
+        unknown_attribute => 'foo',
+      ),
+      '... and our class does not use MooseX::StrictConstructor';
+    ok !$instance->can('unknown_attribute'),   '... and those arguments get ignored';
+    ok !exists $instance->{unknown_attribute}, '... and are not stored internally';
+};
+
+subtest 'no title' => sub {
+    my $person = My::Names->new( name => 'Ovid', );
+    is $person->name, 'Ovid', 'name should be correct';
+    ok !defined $person->title, '... and no title';
+    cmp_ok $person->created, '>', 0, '... and a sane default for created';
+    ok !$person->can('sum'), 'subroutines have been removed from the namespace';
+    is $person->add( [qw/1 3 5 6/] ), 15, 'Our add() method should work';
+    ok !$person->has_title, 'Our predicate shortcut should work';
+};
+
+subtest 'has title' => sub {
+    my $person = My::Names->new( name => 'Ovid', );
+    my $doctor = My::Names->new( name => 'Smith', title => 'Dr.' );
+    is $doctor->name, 'Dr. Smith', 'Titles should show up correctly';
+    cmp_ok $doctor->created, '>=', $person->created,
+      '... and their created date should be correct';
+    ok $doctor->has_title, 'Our predicate shortcut should work';
+};
+
+subtest 'exceptions' => sub {
+    my $person = My::Names->new( name => 'Ovid', );
+
+    throws_ok { $person->title('Mr.') }
+    'Moose::Exception::CannotAssignValueToReadOnlyAccessor',
+      'param() is read-only by default';
+
+    throws_ok { $person->created(11111) }
+    'Moose::Exception::CannotAssignValueToReadOnlyAccessor',
+      'field() is read-only by default';
+
+    throws_ok { $person->add( [] ) }
+    'Error::TypeTiny::Assertion',
+      'passing an empty array reference should be fatal';
+};
+
+done_testing;

--- a/t/exceptions.t
+++ b/t/exceptions.t
@@ -4,7 +4,6 @@ use lib 't/lib';
 use MooseX::Extended::Tests;
 use MooseX::Extended::Core qw(param field);
 use MooseX::Extended::Role ();
-use Capture::Tiny 'capture_stderr';
 
 package Mock::Meta {
     use MooseX::Extended;

--- a/t/lib/MooseX/Extended/Tests.pm
+++ b/t/lib/MooseX/Extended/Tests.pm
@@ -6,6 +6,7 @@ package MooseX::Extended::Tests {
     use Test::Builder;
     use Test::Most ();
     use Import::Into;
+    use Capture::Tiny ();
     use Ref::Util 'is_plain_arrayref';
     use feature 'postderef';
     no warnings 'experimental::postderef';
@@ -42,6 +43,7 @@ package MooseX::Extended::Tests {
         }
 
         Test::Most->import::into($package);
+        Capture::Tiny->import::into( $package, ':all' );
     }
 }
 

--- a/t/lib/My/Moose.pm
+++ b/t/lib/My/Moose.pm
@@ -1,11 +1,10 @@
 package My::Moose {
     use MooseX::Extended::Custom;
 
-    sub import {
-        my ( $class, %args ) = @_;
+    sub import ( $class, %args ) {
         MooseX::Extended::Custom->create(
-            excludes   => [qw/ StrictConstructor c3 /],
-            includes   => ['multi'],
+            excludes => [qw/ StrictConstructor c3 carp /],
+            includes => ['multi'],
             %args
         );
     }

--- a/t/lib/My/Moose.pm
+++ b/t/lib/My/Moose.pm
@@ -1,0 +1,12 @@
+package My::Moose {
+    use MooseX::Extended::Custom;
+
+    sub import {
+        my ( $class, %args ) = @_;
+        MooseX::Extended::Custom->create(
+            excludes   => [qw/ StrictConstructor c3 /],
+            includes   => ['multi'],
+            %args
+        );
+    }
+}

--- a/t/lib/My/Moose/Role.pm
+++ b/t/lib/My/Moose/Role.pm
@@ -1,0 +1,11 @@
+package My::Moose::Role {
+    use MooseX::Extended::Role::Custom;
+
+    sub import {
+        my ( $class, %args ) = @_;
+        MooseX::Extended::Role::Custom->create(
+            excludes => [qw/ WarnOnConflict /],
+            %args    # you need this to allow customization of your customization
+        );
+    }
+}


### PR DESCRIPTION
Create `MooseX::Extended::Custom` and `MooseX::Extended::Role::Custom` to make it easy to create custom Moose analogues without a bunch of boilerplate.