### PR TITLE
Allow `field` to accept an `init_arg` iff the value starts with underscore

### DIFF
--- a/lib/MooseX/Extended.pm
+++ b/lib/MooseX/Extended.pm
@@ -189,7 +189,7 @@ It also exports two functions which are similar to Moose C<has>: C<param> and
 C<field>.
 
 A C<param> is a required parameter (defaults may be used). A C<field> is not
-allowed to be passed to the constructor.
+intended to be passed to the constructor.
 
 Note that the C<has> function is still available, even if it's not needed.
 
@@ -407,7 +407,7 @@ and C<field> attributes, both of which are C<< is => 'ro' >> by default.
 The C<param> is I<required>, whether by passing it to the constructor, or using
 C<default> or C<builder>.
 
-The C<field> is I<forbidden> in the constructor and lazy by default.
+The C<field> defaults to being I<forbidden> in the constructor and lazy.
 
 Here's a short example:
 
@@ -473,7 +473,9 @@ if it encounters an illegal method name for an attribute.
 This also applies to various attributes which allow method names, such as
 C<clone>, C<builder>, C<clearer>, C<writer>, C<reader>, and C<predicate>.
 
-Trying to pass a defined C<init_arg> to C<field> will also this exception.
+Trying to pass a defined C<init_arg> to C<field> will also throw this
+exception, unless the init_arg begins with an underscore. (It is sometimes
+useful to be able to define an init_arg for unit testing.)
 
 =head1 DEBUGGER SUPPORT
 

--- a/lib/MooseX/Extended/Core.pm
+++ b/lib/MooseX/Extended/Core.pm
@@ -254,15 +254,15 @@ sub field ( $meta, $name, %opt_for ) {
     foreach my $attr ( is_plain_arrayref($name) ? @$name : $name ) {
         my %options = %opt_for;    # copy each time to avoid overwriting
         if ( defined( my $init_arg = $options{init_arg} ) ) {
-            throw_exception(
+            $init_arg =~ /\A_/ or throw_exception(
                 'InvalidAttributeDefinition',
                 attribute_name => $name,
                 class_name     => $meta->name,
                 messsage       => "The 'field.init_arg' must be absent or undef, not '$init_arg'",
             );
         }
-        $options{init_arg} = undef;
-        $options{lazy} //= 1;
+        $options{init_arg} //= undef;
+        $options{lazy}     //= 1;
 
         _add_attribute( 'field', $meta, $attr, %options );
     }

--- a/t/field_init_arg.t
+++ b/t/field_init_arg.t
@@ -1,0 +1,27 @@
+#!/usr/bin/env perl
+
+use lib 't/lib';
+use MooseX::Extended::Tests;
+
+package Local::MyClass {
+    use MooseX::Extended;
+    field foo => ( init_arg => '_foo', builder => 1 );
+
+    sub _build_foo {
+        return "quux";
+    }
+}
+
+is(
+    Local::MyClass->new->foo,
+    'quux',
+    'field with default',
+);
+
+is(
+    Local::MyClass->new( _foo => 'quuux' )->foo,
+    'quuux',
+    'field initialized in constructor (init_arg => _foo)',
+);
+
+done_testing;


### PR DESCRIPTION
Includes test case and documentation tweaks. (The current documentation also seems to be missing a verb, probably "throw", and this has now been supplied.)

Issue #29 