### PR TITLE
Add t/handles-via test

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -32,6 +32,7 @@ B::Hooks::AtRuntime = 3                                   ; minimum safe version
 true                = 1.0.2                               ; minimum safe version
 Perl::Critic::Policy::Moose::ProhibitMultipleWiths = 0    ; for xt tests
 Perl::Critic::Policy::Moose::RequireMakeImmutable  = 0    ; for xt tests
+Sub::HandlesVia                                    = 0.023 ; temp for testing
 
 [Prereqs / RuntimeSuggests]
 Syntax::Keyword::MultiSub = 0.02

--- a/t/handles-via.t
+++ b/t/handles-via.t
@@ -1,0 +1,51 @@
+#!/usr/bin/env perl
+
+use lib 't/lib';
+use MooseX::Extended::Tests
+  name   => 'handles-via',
+  module => [ 'Sub::HandlesVia', '0.023' ];
+
+{ package Local::Dummy1; use Test::Requires 'MooseX::Extended' };
+
+BEGIN {
+
+    package ExampleMXX;
+
+    use MooseX::Extended types => ['Str'], debug => 1;
+    use Sub::HandlesVia;
+
+    has eg1 => (
+        is          => 'ro',
+        isa         => Str,
+        handles_via => 'String',
+        handles     => { eg1_append => 'append...' },
+    );
+
+    field eg2 => (
+        is          => 'ro',
+        isa         => Str,
+        handles_via => 'String',
+        handles     => { eg2_append => 'append...' },
+        default     => sub {'eg2'},
+    );
+
+    param eg3 => (
+        is          => 'ro',
+        isa         => Str,
+        handles_via => 'String',
+        handles     => { eg3_append => 'append...' },
+    );
+}
+
+my $obj = ExampleMXX->new(
+    eg1 => 'eg1',
+
+    #    eg2 => 'eg2',
+    eg3 => 'eg3',
+)->eg1_append('x')->eg2_append('x')->eg3_append('x');
+
+is( $obj->eg1, 'eg1x', 'has attribute' );
+is( $obj->eg2, 'eg2x', 'field attribute' );
+is( $obj->eg3, 'eg3x', 'param attribute' );
+
+done_testing;


### PR DESCRIPTION
Test PR to figure out why handles-via is broken. See `t/handles-via.t`

When it fails, I get this:

```
t/handles-via.t .. ExampleMXX: importing types 'Str'
Can't use an undefined value as a subroutine reference at /Users/ovid/perl5/perlbrew/perls/perl-5.28.3/lib/site_perl/5.28.3/darwin-2level/Class/MOP/Class.pm line 324.
BEGIN failed--compilation aborted at t/handles-via.t line 14.
Dubious, test returned 2 (wstat 512, 0x200)
No subtests run

Test Summary Report
-------------------
t/handles-via.t (Wstat: 512 Tests: 0 Failed: 0)
  Non-zero exit status: 2
  Parse errors: No plan found in TAP output
Files=1, Tests=0,  1 wallclock secs ( 0.01 usr  0.00 sys +  0.12 cusr  0.02 csys =  0.15 CPU)
Result: FAIL
```