### PR TITLE
Fix for B::Hooks::AfterRuntime failing sporadically inside stringy eval (issue #32)

### DIFF
--- a/lib/MooseX/Extended.pm
+++ b/lib/MooseX/Extended.pm
@@ -31,7 +31,9 @@ our $VERSION = '0.25';
 
 sub import {
     my ( $class, %args ) = @_;
+    my @caller = caller(0);
     $args{_import_type} = 'class';
+    $args{_caller_eval} = ( $caller[1] =~ /^\(eval/ );
     my $target_class = _assert_import_list_is_valid( $class, \%args );
     my @with_meta    = grep { not $args{excludes}{$_} } qw(field param);
     if (@with_meta) {
@@ -70,7 +72,7 @@ sub _apply_default_features ( $config, $for_class, $params = undef ) {
         say STDERR "We are running under the debugger or using code that uses debugger code (e.g., Devel::Cover). $for_class is not immutable";
     }
     else {
-        unless ( $config->{excludes}{immutable} ) {
+        unless ( $config->{excludes}{immutable} or $config->{_caller_eval} ) {
 
             # after_runtime is loaded too late under the debugger
             eval {
@@ -92,7 +94,7 @@ sub _apply_default_features ( $config, $for_class, $params = undef ) {
             };
         }
     }
-    unless ( $config->{excludes}{true} ) {
+    unless ( $config->{excludes}{true} or $config->{_caller_eval} ) {
         eval {
             load true;
             true->import::into($for_class);    # no need for `1` at the end of the module

--- a/lib/MooseX/Extended/Core.pm
+++ b/lib/MooseX/Extended/Core.pm
@@ -198,6 +198,7 @@ sub _default_import_list () {
         for_class    => Optional [NonEmptyStr],
         types        => Optional [ ArrayRef [NonEmptyStr] ],
         _import_type => Enum [qw/class role/],
+        _caller_eval => Bool,
         includes     => Optional [
             ArrayRef [
                 Enum [

--- a/lib/MooseX/Extended/Custom.pm
+++ b/lib/MooseX/Extended/Custom.pm
@@ -16,8 +16,9 @@ use namespace::autoclean;
 our $VERSION = '0.25';
 
 sub import {
-    my $custom_moose = caller;    # this is our custom Moose definition
-    true->import::into($custom_moose);
+    my @caller = caller(0);
+    my $custom_moose = $caller[0]; # this is our custom Moose definition
+    true->import::into($custom_moose) unless $caller[1] =~ /^\(eval/;
     strict->import::into($custom_moose);
     warnings->import::into($custom_moose);
     namespace::autoclean->import::into($custom_moose);

--- a/lib/MooseX/Extended/Role.pm
+++ b/lib/MooseX/Extended/Role.pm
@@ -33,7 +33,9 @@ my %CONFIG_FOR;
 
 sub import {
     my ( $class, %args ) = @_;
+    my @caller = caller(0);
     $args{_import_type} = 'role';
+    $args{_caller_eval} = ( $caller[1] =~ /^\(eval/ );
     my $target_class = _assert_import_list_is_valid( $class, \%args );
     my @with_meta    = grep { not $args{excludes}{$_} } qw(field param);
     if (@with_meta) {
@@ -60,7 +62,7 @@ sub _apply_default_features ( $config, $for_class, $params ) {
 
     Carp->import::into($for_class)                         unless $config->{excludes}{carp};
     namespace::autoclean->import::into($for_class)         unless $config->{excludes}{autoclean};
-    true->import                                           unless $config->{excludes}{true};
+    true->import                                           unless $config->{excludes}{true} || $config->{_caller_eval};
     MooseX::Role::WarnOnConflict->import::into($for_class) unless $config->{excludes}{WarnOnConflict};
 
     feature->import( _enabled_features() );

--- a/lib/MooseX/Extended/Role/Custom.pm
+++ b/lib/MooseX/Extended/Role/Custom.pm
@@ -16,8 +16,9 @@ use namespace::autoclean;
 our $VERSION = '0.25';
 
 sub import {
-    my $custom_moose = caller;    # this is our custom Moose definition
-    true->import::into($custom_moose);
+    my @caller = caller(0);
+    my $custom_moose = $caller[0]; # this is our custom Moose definition
+    true->import::into($custom_moose) unless $caller[1] =~ /^\(eval/;;
     strict->import::into($custom_moose);
     warnings->import::into($custom_moose);
     namespace::autoclean->import::into($custom_moose);

--- a/t/stringy-eval.t
+++ b/t/stringy-eval.t
@@ -1,0 +1,15 @@
+use strict;
+use Test::More;
+
+BEGIN {
+	for my $i ( 1 .. 20 ) {
+		my $e = do {
+			local $@;
+			eval qq{package Local::Class$i; use MooseX::Extended};
+			$@;
+		};
+		ok( !$e, "Local::Class$i compiled ok" ) or diag( "Got: $e" );
+	}
+};
+
+done_testing;

--- a/t/stringy-eval.t
+++ b/t/stringy-eval.t
@@ -10,6 +10,17 @@ BEGIN {
 		};
 		ok( !$e, "Local::Class$i compiled ok" ) or diag( "Got: $e" );
 	}
+	
+	for my $i ( 1 .. 20 ) {
+		my $e = do {
+			local $@;
+			eval qq{package Local::Role$i; use MooseX::Extended::Role};
+			$@;
+		};
+		ok( !$e, "Local::Role$i compiled ok" ) or diag( "Got: $e" );
+	}
 };
+
+ok 1;
 
 done_testing;


### PR DESCRIPTION
I think this should fix issue #32.

I've only really tested it with MooseX::Extended. Probably needs tests for MooseX::Extended::Role and MooseX::Extended::Custom too.

Auto-excluding true.pm in stringy eval should be harmless as true.pm is only useful when a module is being loaded from a file using `use`/`require`.

Not being able to make the class immutable is an annoyance, but it shouldn't have any practical effect for most people, and it's already noted that this fails when being run under the debugger.