### PR TITLE
naked_fields warning (issue #37)

### DIFF
--- a/lib/MooseX/Extended/Core.pm
+++ b/lib/MooseX/Extended/Core.pm
@@ -238,8 +238,9 @@ sub _apply_optional_features ( $config, $for_class ) {
 }
 
 sub param ( $meta, $name, %opt_for ) {
-    $opt_for{is}       //= 'ro';
-    $opt_for{required} //= 1;
+    $opt_for{is}            //= 'ro';
+    $opt_for{required}      //= 1;
+    $opt_for{_caller_level} //= 1;
 
     # "has [@attributes]" versus "has $attribute"
     foreach my $attr ( is_plain_arrayref($name) ? @$name : $name ) {
@@ -253,7 +254,8 @@ sub param ( $meta, $name, %opt_for ) {
 }
 
 sub field ( $meta, $name, %opt_for ) {
-    $opt_for{is} //= 'ro';
+    $opt_for{is}            //= 'ro';
+    $opt_for{_caller_level} //= 1;
 
     # "has [@attributes]" versus "has $attribute"
     foreach my $attr ( is_plain_arrayref($name) ? @$name : $name ) {
@@ -336,13 +338,14 @@ sub _add_attribute ( $attr_type, $meta, $name, %opt_for ) {
         and $opt_for{is} eq 'ro' )
     {
 
-        my $call_level = 2;    # XXX: better way than hard-coding?
+        my $call_level = 1 + $opt_for{_caller_level};
         my ( $package, $filename, $line ) = caller($call_level);
         Carp::carp("$attr_type '$name' is read-only and has no init_arg or default, defined at $filename line $line\n")
           if $] ge '5.028'
           and warnings::enabled_at_level( 'MooseX::Extended::naked_fields', $call_level );
     }
 
+    delete $opt_for{_caller_level};
     _debug( "Setting $attr_type, '$name'", \%opt_for );
     $meta->add_attribute( $name, %opt_for );
 }

--- a/lib/MooseX/Extended/Core.pm
+++ b/lib/MooseX/Extended/Core.pm
@@ -333,7 +333,7 @@ sub _add_attribute ( $attr_type, $meta, $name, %opt_for ) {
         and not exists $opt_for{default}
         and not exists $opt_for{builder}
         and not defined $opt_for{init_arg}
-        and ( not defined $opt_for{is} or $opt_for{is} eq 'ro' ) )
+        and $opt_for{is} eq 'ro' )
     {
 
         my $call_level = 2;    # XXX: better way than hard-coding?

--- a/lib/MooseX/Extended/Core.pm
+++ b/lib/MooseX/Extended/Core.pm
@@ -339,7 +339,8 @@ sub _add_attribute ( $attr_type, $meta, $name, %opt_for ) {
         my $call_level = 2;    # XXX: better way than hard-coding?
         my ( $package, $filename, $line ) = caller($call_level);
         Carp::carp("$attr_type '$name' is read-only and has no init_arg or default, defined at $filename line $line\n")
-          if warnings::enabled_at_level( 'MooseX::Extended::naked_fields', $call_level );
+          if $] ge '5.028'
+          and warnings::enabled_at_level( 'MooseX::Extended::naked_fields', $call_level );
     }
 
     _debug( "Setting $attr_type, '$name'", \%opt_for );

--- a/lib/MooseX/Extended/Core.pm
+++ b/lib/MooseX/Extended/Core.pm
@@ -328,12 +328,12 @@ sub _add_attribute ( $attr_type, $meta, $name, %opt_for ) {
 
     %opt_for = _maybe_add_cloning_method( $meta, $name, %opt_for );
 
-    if (    !exists $opt_for{accessor}
-        and !exists $opt_for{writer}
-        and !exists $opt_for{default}
-        and !exists $opt_for{builder}
-        and !defined $opt_for{init_arg}
-        and ( $opt_for{is} // 'ro' ) eq 'ro' )
+    if (    not exists $opt_for{accessor}
+        and not exists $opt_for{writer}
+        and not exists $opt_for{default}
+        and not exists $opt_for{builder}
+        and not defined $opt_for{init_arg}
+        and ( not defined $opt_for{is} or $opt_for{is} eq 'ro' ) )
     {
 
         my $call_level = 2;    # XXX: better way than hard-coding?

--- a/lib/MooseX/Extended/Core.pm
+++ b/lib/MooseX/Extended/Core.pm
@@ -45,7 +45,7 @@ sub _enabled_features  {qw/signatures postderef postderef_qq :5.20/}            
 sub _disabled_warnings {qw/experimental::signatures experimental::postderef/}    # internal use only
 
 warnings::register_categories(
-   'MooseX::Extended::naked_fields',
+    'MooseX::Extended::naked_fields',
 );
 
 # Should this be in the metaclass? It feels like it should, but
@@ -328,17 +328,18 @@ sub _add_attribute ( $attr_type, $meta, $name, %opt_for ) {
 
     %opt_for = _maybe_add_cloning_method( $meta, $name, %opt_for );
 
-    if ( !exists $opt_for{accessor}
-    and  !exists $opt_for{writer}
-    and  !exists $opt_for{default}
-    and  !exists $opt_for{builder}
-    and  !defined $opt_for{init_arg}
-    and  ( $opt_for{is} // 'ro' ) eq 'ro' ) {
+    if (    !exists $opt_for{accessor}
+        and !exists $opt_for{writer}
+        and !exists $opt_for{default}
+        and !exists $opt_for{builder}
+        and !defined $opt_for{init_arg}
+        and ( $opt_for{is} // 'ro' ) eq 'ro' )
+    {
 
-        my $call_level = 2; # XXX: better way than hard-coding?
-        my ( $package, $filename, $line ) = caller( $call_level );
-        Carp::carp( "$attr_type '$name' is read-only and has no init_arg or default, defined at $filename line $line\n" )
-            if warnings::enabled_at_level( 'MooseX::Extended::naked_fields', $call_level );
+        my $call_level = 2;    # XXX: better way than hard-coding?
+        my ( $package, $filename, $line ) = caller($call_level);
+        Carp::carp("$attr_type '$name' is read-only and has no init_arg or default, defined at $filename line $line\n")
+          if warnings::enabled_at_level( 'MooseX::Extended::naked_fields', $call_level );
     }
 
     _debug( "Setting $attr_type, '$name'", \%opt_for );

--- a/lib/MooseX/Extended/Core.pm
+++ b/lib/MooseX/Extended/Core.pm
@@ -44,6 +44,10 @@ our @EXPORT_OK = qw(
 sub _enabled_features  {qw/signatures postderef postderef_qq :5.20/}             # internal use only
 sub _disabled_warnings {qw/experimental::signatures experimental::postderef/}    # internal use only
 
+warnings::register_categories(
+   'MooseX::Extended::naked_fields',
+);
+
 # Should this be in the metaclass? It feels like it should, but
 # the MOP really doesn't support these edge cases.
 my %CONFIG_FOR;
@@ -323,6 +327,19 @@ sub _add_attribute ( $attr_type, $meta, $name, %opt_for ) {
     }
 
     %opt_for = _maybe_add_cloning_method( $meta, $name, %opt_for );
+
+    if ( !exists $opt_for{accessor}
+    and  !exists $opt_for{writer}
+    and  !exists $opt_for{default}
+    and  !exists $opt_for{builder}
+    and  !defined $opt_for{init_arg}
+    and  ( $opt_for{is} // 'ro' ) eq 'ro' ) {
+
+        my $call_level = 2; # XXX: better way than hard-coding?
+        my ( $package, $filename, $line ) = caller( $call_level );
+        Carp::carp( "$attr_type '$name' is read-only and has no init_arg or default, defined at $filename line $line\n" )
+            if warnings::enabled_at_level( 'MooseX::Extended::naked_fields', $call_level );
+    }
 
     _debug( "Setting $attr_type, '$name'", \%opt_for );
     $meta->add_attribute( $name, %opt_for );

--- a/lib/MooseX/Extended/Core.pm
+++ b/lib/MooseX/Extended/Core.pm
@@ -238,9 +238,9 @@ sub _apply_optional_features ( $config, $for_class ) {
 }
 
 sub param ( $meta, $name, %opt_for ) {
-    $opt_for{is}            //= 'ro';
-    $opt_for{required}      //= 1;
-    $opt_for{_caller_level} //= 1;
+    $opt_for{is}          //= 'ro';
+    $opt_for{required}    //= 1;
+    $opt_for{_call_level} //= 1;
 
     # "has [@attributes]" versus "has $attribute"
     foreach my $attr ( is_plain_arrayref($name) ? @$name : $name ) {
@@ -254,8 +254,8 @@ sub param ( $meta, $name, %opt_for ) {
 }
 
 sub field ( $meta, $name, %opt_for ) {
-    $opt_for{is}            //= 'ro';
-    $opt_for{_caller_level} //= 1;
+    $opt_for{is}          //= 'ro';
+    $opt_for{_call_level} //= 1;
 
     # "has [@attributes]" versus "has $attribute"
     foreach my $attr ( is_plain_arrayref($name) ? @$name : $name ) {
@@ -338,14 +338,14 @@ sub _add_attribute ( $attr_type, $meta, $name, %opt_for ) {
         and $opt_for{is} eq 'ro' )
     {
 
-        my $call_level = 1 + $opt_for{_caller_level};
+        my $call_level = 1 + $opt_for{_call_level};
         my ( $package, $filename, $line ) = caller($call_level);
         Carp::carp("$attr_type '$name' is read-only and has no init_arg or default, defined at $filename line $line\n")
           if $] ge '5.028'
           and warnings::enabled_at_level( 'MooseX::Extended::naked_fields', $call_level );
     }
 
-    delete $opt_for{_caller_level};
+    delete $opt_for{_call_level};
     _debug( "Setting $attr_type, '$name'", \%opt_for );
     $meta->add_attribute( $name, %opt_for );
 }

--- a/lib/MooseX/Extended/Manual/Shortcuts.pod
+++ b/lib/MooseX/Extended/Manual/Shortcuts.pod
@@ -178,3 +178,5 @@ with no C<init_arg> and no default or builder, will result in a warning.
 If you wish to disable this warning you can.
 
   no warnings 'MooseX::Extended::naked_fields';
+
+This warning is only available on Perl >= 5.028.

--- a/lib/MooseX/Extended/Manual/Shortcuts.pod
+++ b/lib/MooseX/Extended/Manual/Shortcuts.pod
@@ -170,3 +170,11 @@ You may also pass a coderef to `builder`:
 This is different from C<< default => sub {...} >> because it will install a
 C<_build_created> method for you. This is useful if you with to allow a
 subclass to override this method.
+
+=head1 DIAGNOSTICS
+
+Attributes defined using C<param> or C<field> which are read-only
+with no C<init_arg> and no default or builder, will result in a warning.
+If you wish to disable this warning you can.
+
+  no warnings 'MooseX::Extended::naked_fields';

--- a/t/warnings.t
+++ b/t/warnings.t
@@ -3,13 +3,16 @@
 use lib 't/lib';
 use MooseX::Extended::Tests;
 
+plan skip_all => 'Perl >= 5.028 only'
+    if $] lt '5.028';
+
 warnings_like {
 
     package Local::Test1;
     use MooseX::Extended;
     field 'foo';
 }
-qr/field 'foo' is read-only and has no init_arg or default, defined at .+\bwarnings.t line 10/;
+qr/field 'foo' is read-only and has no init_arg or default, defined at .+\bwarnings.t line 13/;
 
 warning_is {
 

--- a/t/warnings.t
+++ b/t/warnings.t
@@ -4,16 +4,20 @@ use lib 't/lib';
 use MooseX::Extended::Tests;
 
 warnings_like {
+
     package Local::Test1;
     use MooseX::Extended;
     field 'foo';
-} qr/field 'foo' is read-only and has no init_arg or default, defined at .+\bwarnings.t line 9/;
+}
+qr/field 'foo' is read-only and has no init_arg or default, defined at .+\bwarnings.t line 10/;
 
 warning_is {
+
     package Local::Test2;
     use MooseX::Extended;
     no warnings 'MooseX::Extended::naked_fields';
     field 'bar';
-} undef;
+}
+undef;
 
 done_testing;

--- a/t/warnings.t
+++ b/t/warnings.t
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+
+use lib 't/lib';
+use MooseX::Extended::Tests;
+
+warnings_like {
+    package Local::Test1;
+    use MooseX::Extended;
+    field 'foo';
+} qr/field 'foo' is read-only and has no init_arg or default, defined at .+\bwarnings.t line 9/;
+
+warning_is {
+    package Local::Test2;
+    use MooseX::Extended;
+    no warnings 'MooseX::Extended::naked_fields';
+    field 'bar';
+} undef;
+
+done_testing;


### PR DESCRIPTION
I'm pretty sure this is a comprehensive condition for checking that a field is unsettable in any way.

```perl
    if ( !exists $opt_for{accessor}
    and  !exists $opt_for{writer}
    and  !exists $opt_for{default}
    and  !exists $opt_for{builder}
    and  !defined $opt_for{init_arg}
    and  ( $opt_for{is} // 'ro' ) eq 'ro' ) {
```

I don't especially like the hard-coding of the call level; it could break down if a MooseX::Extended::Custom module wraps `field` or `param`. Can you think of a better solution for that?